### PR TITLE
Remove ansible

### DIFF
--- a/docker/jenkins/Dockerfile
+++ b/docker/jenkins/Dockerfile
@@ -11,11 +11,6 @@ RUN apt-get update
 RUN apt-get install -y apt-transport-https ca-certificates curl gnupg2 software-properties-common \
       python-setuptools python-dev build-essential
 
-# Ansible
-RUN easy_install pip
-RUN pip install --upgrade pip
-RUN pip install ansible
-
 RUN curl -fsSL https://download.docker.com/linux/debian/gpg | sudo apt-key add -
 RUN add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debian stretch stable"
 RUN apt-get update


### PR DESCRIPTION
Remove Ansible to make Jenkins Dockerfile more independent.
Tools like Ansible, Capistrano can be used by Docker containers